### PR TITLE
[BUGFIX] Strict mode for array_search in pagination service for perfo…

### DIFF
--- a/Classes/Service/PaginationService.php
+++ b/Classes/Service/PaginationService.php
@@ -157,7 +157,7 @@ class PaginationService implements SingletonInterface
 
         /** @var QueryResult $posts */
         $posts = $this->postRepository->findByThreadOnFirstLevel($thread)->toArray();
-        $position = array_search($post, $posts) + 1;
+        $position = array_search($post, $posts, true) + 1;
         if (false == $position) {
             return 0;
         }


### PR DESCRIPTION
…rmance reasons.

Strict mode in array_search causes, that there is comparing with === instaed of == which means that there is no longer a cast on the properties which means that the process  goes faster.

More informations at: https://stackoverflow.com/questions/2401478/why-is-faster-than-in-php